### PR TITLE
Ctorng fixes

### DIFF
--- a/pymtl/model/Model.py
+++ b/pymtl/model/Model.py
@@ -606,8 +606,13 @@ class Model( object ):
     # Generate a unique name for the Model instance based on its params
     # http://stackoverflow.com/a/5884123
     try:
-      hashables = frozenset({ x for x in model._args.items()
-                              if isinstance( x[1], collections.Hashable ) })
+      hashables = { x for x in model._args.items()
+                    if isinstance( x[1], collections.Hashable ) }
+
+      # Also add class name to prevent same-name same-args collisions
+      hashables.add( model.__class__ )
+
+      hashables = frozenset( hashables )
       suffix = abs( hash( hashables ) )
       return name + '_' + hex( suffix )
     # No _args attribute, so no need to create a specialized name

--- a/pymtl/model/Model.py
+++ b/pymtl/model/Model.py
@@ -56,6 +56,21 @@ class Model( object ):
   vbb_no_reset   = False  # Do not generate reset port in Verilog
   vbb_no_clk     = False  # Do not generate clk   port in Verilog
 
+  # The following option allows annotation of an array when translating to
+  # Verilog. For example, in order for FPGA synthesis tools to infer BRAM,
+  # the array must be annotated like this:
+  #
+  #   (* RAM_STYLE="BLOCK" *) reg [p_col_width-1:0]  ram [31:0];
+  #
+  # This option is set up as a dict with the names of the arrays to
+  # annotate as keys and annotation strings as values. For example,
+  # generating the above annotation looks like this:
+  #
+  #   vannotate = { 'ram': '(* RAM_STYLE="BLOCK" *)' }
+  #
+
+  vannotate_arrays = {}     # Annotate arrays
+
   #=====================================================================
   # Modeling API
   #=====================================================================

--- a/pymtl/tools/translation/verilog_structural.py
+++ b/pymtl/tools/translation/verilog_structural.py
@@ -29,7 +29,7 @@ def header( model, symtab, enable_blackbox=False ):
 
   dump_vcd = hasattr( model, 'vcd_file' ) and model.vcd_file != ''
   s   += '// dump-vcd: {}'.format( dump_vcd ) + endl
-  
+
   if enable_blackbox:
     if model.vblackbox:
       s += '// This module is treated as a black box' + endl
@@ -338,8 +338,15 @@ def array_declarations( model, symtab ):
   #---------------------------------------------------------------------
   def _gen_array_to_output( ports ):
     if isinstance( ports[0], (Wire,InPort,OutPort) ):
-      stmts = '  reg    [{:4}:0] {}[0:{}];\n' \
-              .format(ports[0].nbits-1, ports.name, len(ports)-1)
+
+      # Annotate arrays if vannotate_arrays is available
+      annotation = ''
+      if model.vannotate_arrays:
+        if ports.name in model.vannotate_arrays:
+          annotation = model.vannotate_arrays[ports.name] + ' '
+
+      stmts = '  {}reg    [{:4}:0] {}[0:{}];\n' \
+              .format(annotation, ports[0].nbits-1, ports.name, len(ports)-1)
       for i, port in enumerate(ports):
         stmts += '  assign {0} = {1}[{2:3}];\n' \
                  .format(signal_to_str(port, None, model), ports.name, i)


### PR DESCRIPTION
My commit messages both have "see mores" with details. My main other concern here though might be performance for the hashing method.

Derek used hash() on a frozenset of the arguments for performance reasons:

- https://github.com/cornell-brg/pymtl/blob/ece4750/pymtl/model/Model.py#L591-L592

Or at least that is the feeling I got from reading that stackoverflow link. I put __class__ into the frozenset in order to properly differentiate the two Mux's I had problems with. The __class__ string includes the hierarchy to get to the module, so I thought it was the smallest thing I could add to create the differentiation. But I'm not sure if calling __class__ is actually expensive or anything...

Chris