### PR TITLE
Fix for collecting arguments in a Model

### DIFF
--- a/pymtl/model/Model_test.py
+++ b/pymtl/model/Model_test.py
@@ -337,6 +337,70 @@ def test_PortConstAssertSize():
     m = inst_elab_model( PortConstAssertSize2 )
 
 #-----------------------------------------------------------------------
+# ModelArgsHash
+#-----------------------------------------------------------------------
+# Verify that we create unique hashes for the following four
+# combinations:
+#
+#   - constructor without default values + instance uses pos args
+#   - constructor without default values + instance uses kw  args
+#   - constructor with    default values + instance uses pos args
+#   - constructor with    default values + instance uses kw  args
+#
+
+def cmp_class_name_eq( model1, model2 ):
+  model1.elaborate()
+  model2.elaborate()
+  assert model1.class_name == model2.class_name
+
+def cmp_class_name_neq( model1, model2 ):
+  model1.elaborate()
+  model2.elaborate()
+  assert model1.class_name != model2.class_name
+
+class ModelArgsHashWithoutDefault( Model ):
+  def __init__( s, arg1, arg2 ):
+    s.arg1 = arg1
+    s.arg2 = arg2
+
+def test_ModelArgsHashWithoutDefault():
+
+  M = ModelArgsHashWithoutDefault
+
+  cmp_class_name_eq  ( M(      3,      4 ), M(      3,      4 ) )
+  cmp_class_name_neq ( M(      3,      4 ), M(      5,      6 ) )
+
+  cmp_class_name_eq  ( M(      3, arg2=4 ), M(      3, arg2=4 ) )
+  cmp_class_name_neq ( M(      3, arg2=4 ), M(      5, arg2=6 ) )
+
+  cmp_class_name_eq  ( M( arg1=3, arg2=4 ), M( arg1=3, arg2=4 ) )
+  cmp_class_name_neq ( M( arg1=3, arg2=4 ), M( arg1=5, arg2=6 ) )
+
+class ModelArgsHashWithDefault( Model ):
+  def __init__( s, arg1=1, arg2=2 ):
+    s.arg1 = arg1
+    s.arg2 = arg2
+
+def test_ModelArgsHashWithDefault():
+
+  M = ModelArgsHashWithDefault
+
+  cmp_class_name_eq  ( M(      3,      4 ), M(      3,      4 ) )
+  cmp_class_name_neq ( M(      3,      4 ), M(      5,      6 ) )
+
+  cmp_class_name_eq  ( M(      3, arg2=4 ), M(      3, arg2=4 ) )
+  cmp_class_name_neq ( M(      3, arg2=4 ), M(      5, arg2=6 ) )
+
+  cmp_class_name_eq  ( M( arg1=3, arg2=4 ), M( arg1=3, arg2=4 ) )
+  cmp_class_name_neq ( M( arg1=3, arg2=4 ), M( arg1=5, arg2=6 ) )
+
+  cmp_class_name_eq  ( M(      3 ), M(      3 ) )
+  cmp_class_name_neq ( M(      3 ), M(      5 ) )
+
+  cmp_class_name_eq  ( M( arg1=3 ), M( arg1=3 ) )
+  cmp_class_name_neq ( M( arg1=3 ), M( arg1=5 ) )
+
+#-----------------------------------------------------------------------
 # ClassNameCollision
 #-----------------------------------------------------------------------
 # A model's class_name is generated during elaboration based on a hash of

--- a/pymtl/model/Model_test.py
+++ b/pymtl/model/Model_test.py
@@ -376,6 +376,9 @@ def test_ModelArgsHashWithoutDefault():
   cmp_class_name_eq  ( M( arg1=3, arg2=4 ), M( arg1=3, arg2=4 ) )
   cmp_class_name_neq ( M( arg1=3, arg2=4 ), M( arg1=5, arg2=6 ) )
 
+  cmp_class_name_eq  ( M( arg2=4, arg1=3 ), M( arg1=3, arg2=4 ) )
+  cmp_class_name_neq ( M( arg2=4, arg1=3 ), M( arg1=5, arg2=6 ) )
+
 class ModelArgsHashWithDefault( Model ):
   def __init__( s, arg1=1, arg2=2 ):
     s.arg1 = arg1
@@ -393,6 +396,9 @@ def test_ModelArgsHashWithDefault():
 
   cmp_class_name_eq  ( M( arg1=3, arg2=4 ), M( arg1=3, arg2=4 ) )
   cmp_class_name_neq ( M( arg1=3, arg2=4 ), M( arg1=5, arg2=6 ) )
+
+  cmp_class_name_eq  ( M( arg2=4, arg1=3 ), M( arg1=3, arg2=4 ) )
+  cmp_class_name_neq ( M( arg2=4, arg1=3 ), M( arg1=5, arg2=6 ) )
 
   cmp_class_name_eq  ( M(      3 ), M(      3 ) )
   cmp_class_name_neq ( M(      3 ), M(      5 ) )

--- a/pymtl/model/metaclasses.py
+++ b/pymtl/model/metaclasses.py
@@ -78,31 +78,44 @@ class MetaCollectArgs( MetaListConstructor ):
     """
 
     # Get the constructor prototype
+
     argspec = inspect.getargspec( self.__init__ )
 
     # Create an argument dictionary
+
     argdict = collections.OrderedDict()
 
     # Collect all positional arguments (except first, which is self)
+
     for i, arg_value in enumerate( args ):
       key, value = argspec.args[i+1], arg_value
       argdict[ key ] = value
 
     # Collect all keyword arguments
-    num_kwargs = len( argspec.args ) - len( args ) - 1
-    if argspec.defaults and num_kwargs:
-      for i, arg_name in enumerate( argspec.args[-num_kwargs:] ):
-        key, value = arg_name, argspec.defaults[ i ]
-        if arg_name in kwargs:
-          value = kwargs[ arg_name ]
-        argdict[ key ] = value
+
+    for key, value in kwargs.items():
+      argdict[ key ] = value
+
+    # Handle default arguments. Iterate backwards through default values,
+    # matching the default value to the corresponding argument name, then
+    # add the corresponding argument as long as we did not already add it
+    # above.
+
+    if argspec.defaults:
+      for i, default_value in enumerate( reversed(argspec.defaults) ):
+        arg_name = argspec.args[ len(argspec.args) - i - 1 ]
+        if arg_name not in argdict:
+          argdict[ arg_name ] = default_value
 
     # Create the instance
+
     inst = super( MetaCollectArgs, self ).__call__( *args, **kwargs )
 
     # Add the argdict to inst
+
     inst._args = argdict
 
     # Return the instance
+
     return inst
 


### PR DESCRIPTION
There was a bug related to collecting arguments for a `Model` when the constructor was defined without default values and the Model was instantiated using keywords. The following illustrates the problem:

```python
 >>> from pymtl import *
 >>> class A(Model):
 ...   def __init__( s, arg1, arg2 ):
 ...     s.arg1 = arg1
 ...     s.arg2 = arg2
 ...
 >>> a1 = A( arg1=1, arg2=2 )
 >>> a2 = A( arg1=3, arg2=24)
 >>> a1.elaborate()
 >>> a2.elaborate()
 >>> a1.class_name
 'A_0x395645cdf5e6932f'
 >>> a2.class_name
 'A_0x395645cdf5e6932f'
```

These should have different class names because they have different arguments. I have added a test case which failed due to the above issue, I fixed the `__call__` method in the `metaclasses.py` magic, and now these test cases pass.

@dmlockhart can you take a look and see what you think after TravisCI runs all of the tests? Before merging, I would like to get your feedback.