### PR TITLE
[SC import] Add support for implicit/nested set_port, and additional sourcefolder.

### DIFF
--- a/pymtl/tools/integration/systemc.py
+++ b/pymtl/tools/integration/systemc.py
@@ -51,6 +51,12 @@ class SomeMeta( MetaCollectArgs ):
     inst.vcd_file = '__dummy__'
     inst.elaborate()
     
+    # Postpone port dict until elaboration.
+    if not inst._port_dict:
+      inst._port_dict = { port.name: port for port in inst.get_ports() }
+    else:
+      print(inst._port_dict)
+    
     sc_module_name  = inst.__class__.__name__  
     model_name      = inst.class_name
     c_wrapper_file  = model_name + '_sc.cpp'
@@ -311,7 +317,4 @@ class SystemCModel( Model ):
 
     if not self._param_dict:
       self._param_dict = self._args
-
-    if not self._port_dict:
-      self._port_dict = { port.name: port for port in self.get_ports() }
 

--- a/pymtl/tools/integration/systemc.py
+++ b/pymtl/tools/integration/systemc.py
@@ -44,10 +44,6 @@ class SomeMeta( MetaCollectArgs ):
         x += os.sep
       inst.sourcefolder[i] = x
     
-    # TODO: currently I don't call translation tool for systemc import,
-    # but I guess I need to organize the following piece of code into 
-    # some "systemcimporttool"
-    
     inst.vcd_file = '__dummy__'
     inst.elaborate()
     
@@ -311,9 +307,15 @@ class SystemCModel( Model ):
       file_ = inspect.getfile( self.__class__ )
       self.sourcefile = [ self.modulename ]
       
+    # If the sourcefolder is not defined then define it as the same
+    # path as the python file, otherwise just by default append 
+    # the python file path to s.sourcefolder
+    
+    file_ = inspect.getfile( self.__class__ )
     if not self.sourcefolder:
-      file_ = inspect.getfile( self.__class__ )
       self.sourcefolder = [ os.path.dirname( file_ ) ]
+    else:
+      self.sourcefolder.append( os.path.dirname( file_ ) )
 
     if not self._param_dict:
       self._param_dict = self._args

--- a/pymtl/tools/integration/systemc_tests/combinational/Adder_multi_bw_test.py
+++ b/pymtl/tools/integration/systemc_tests/combinational/Adder_multi_bw_test.py
@@ -56,11 +56,7 @@ test_16  = [ (0x1234, 0x2143), (0xffe0, 0x0001) ]
 test_40  = [ (0x1234567890, 0x2109876543), (0xffe0, 0x0001) ]
 test_100 = [ (0x1234567890123456789012345, 0x2109876543210987654321098), (0xffe0, 0x0001) ]
 
-
-# TODO This is hacky, since I have to register modules earlier
-# in systemc world.
-
-@pytest.mark.parametrize( "a,b", test_16)
+@pytest.mark.parametrize( "a,b", test_16 )
 def test_Adder_16( a, b ):
   m, sim = _sim_setup( Adder_16() )
   
@@ -76,7 +72,7 @@ def test_Adder_16( a, b ):
   
   m.destroy()
 
-@pytest.mark.parametrize( "a,b", test_40)
+@pytest.mark.parametrize( "a,b", test_40 )
 def test_Adder_40( a, b ):
   m, sim = _sim_setup( Adder_40() )
   
@@ -91,7 +87,7 @@ def test_Adder_40( a, b ):
     assert m.res_c == a + b + i + i
   m.destroy()
 
-@pytest.mark.parametrize( "a,b", test_100)
+@pytest.mark.parametrize( "a,b", test_100 )
 def test_Adder_100( a, b ):
   m, sim = _sim_setup( Adder_100() )
   
@@ -106,7 +102,7 @@ def test_Adder_100( a, b ):
     assert m.res_c == a + b + i + i
   m.destroy()
   
-@pytest.mark.parametrize( "a,b", test_16)
+@pytest.mark.parametrize( "a,b", test_16 )
 def test_Adder_16_2( a, b ):
   m, sim = _sim_setup( Adder_16() )
   

--- a/pymtl/tools/integration/systemc_tests/implicit_set_ports/RegIncr_implicit_SC.cc
+++ b/pymtl/tools/integration/systemc_tests/implicit_set_ports/RegIncr_implicit_SC.cc
@@ -1,0 +1,31 @@
+#include "RegIncr_implicit_SC.h"
+
+void RegIncr_implicit_SC::incr()
+{
+  // combinational incrementer
+  out.write( wire.read() + 1 );
+}
+
+void RegIncr_implicit_SC::reg()
+{
+  // reset 
+  wire.write( 0 ); 
+  wait();
+  
+  while (1)
+  {
+    wire.write( in_.read() );
+    wait();
+  }
+}
+
+#ifndef SYNTHESIS
+#include <cstdio>
+
+void RegIncr_implicit_SC::line_trace(char *str)
+{
+  char tmp[50];
+  sprintf(tmp,"in=%u out=%u",in_.read().to_uint(),out.read().to_uint());
+  strcpy(str,tmp);
+}
+#endif

--- a/pymtl/tools/integration/systemc_tests/implicit_set_ports/RegIncr_implicit_SC.h
+++ b/pymtl/tools/integration/systemc_tests/implicit_set_ports/RegIncr_implicit_SC.h
@@ -1,0 +1,28 @@
+#include "systemc.h"
+
+SC_MODULE(RegIncr_implicit_SC)
+{
+public:
+  sc_in <bool> clk;
+  sc_in <bool> reset;
+  sc_in <sc_uint<32> > in_;
+  sc_out<sc_uint<32> > out;
+  
+  sc_signal<sc_uint<32> > wire;
+  
+  SC_CTOR(RegIncr_implicit_SC)
+  {
+    SC_METHOD(incr);
+    sensitive << wire;
+    
+    SC_CTHREAD(reg, clk.pos());
+    
+    reset_signal_is(reset, 1);
+  }
+protected:  
+  void incr();
+  void reg();
+  
+public:
+  void line_trace(char* str);
+};

--- a/pymtl/tools/integration/systemc_tests/implicit_set_ports/RegIncr_implicit_SC.py
+++ b/pymtl/tools/integration/systemc_tests/implicit_set_ports/RegIncr_implicit_SC.py
@@ -1,0 +1,15 @@
+#=======================================================================
+# RegIncr_implicit_SC.py
+#=======================================================================
+
+from pymtl import *
+
+class RegIncr_implicit_SC( SystemCModel ):
+  
+  def __init__( s ):
+
+    s.in_ = InPort ( Bits(32) )
+    s.out = OutPort( Bits(32) )
+  
+  # When the port names in SystemC module matches the defined ports 
+  # above, plus "clk" and "reset", we don't need to set_ports.

--- a/pymtl/tools/integration/systemc_tests/implicit_set_ports/RegIncr_implicit_SC_test.py
+++ b/pymtl/tools/integration/systemc_tests/implicit_set_ports/RegIncr_implicit_SC_test.py
@@ -1,0 +1,101 @@
+#=======================================================================
+# RegIncr_implicit_SC_test.py
+#=======================================================================
+
+import random
+import pytest
+
+from pymtl import *
+
+from RegIncr_implicit_SC     import RegIncr_implicit_SC
+
+simple_test_vectors = [
+  ( 4,  5),
+  ( 6,  7),
+  ( 2,  3),
+  (15, 16),
+  ( 8,  9),
+  ( 0,  1),
+  (10, 11),
+]
+
+#-----------------------------------------------------------------------
+# test_simple
+#-----------------------------------------------------------------------
+def test_simple():
+
+  # instantiate the model and elaborate it
+
+  model = RegIncr_implicit_SC()
+
+  model.elaborate()
+
+  # create the simulator
+
+  sim = SimulationTool( model )
+  sim.reset() # remember to reset!
+  
+  # verify the model
+
+  print
+
+  for input_vector, expected_out in simple_test_vectors:
+
+    model.in_.value = input_vector
+    
+    sim.eval_combinational() # This is only for this model's line trace
+                             # and is not guaranteed to work in general
+                             # since verilog import already have this 
+                             # inport trace problem.
+    sim.print_line_trace()
+    
+    sim.cycle()
+
+    assert model.out == expected_out
+
+  sim.print_line_trace()
+  
+  model.destroy()
+
+#-----------------------------------------------------------------------
+# gen_test_vectors
+#-----------------------------------------------------------------------
+def gen_test_vectors( nbits, size=10 ):
+
+  vectors = []
+  for i in range( size ):
+    input_value = Bits( nbits, random.randrange( 2**nbits ) )
+    vectors.append( (input_value, input_value + 1) )
+
+  return vectors
+
+#-----------------------------------------------------------------------
+# test_random
+#-----------------------------------------------------------------------
+def test_random():
+
+  # elaborate model
+
+  model = RegIncr_implicit_SC()
+  model.elaborate()
+
+  # create the simulator
+
+  sim = SimulationTool( model )
+  sim.reset() # remember to reset!
+
+  # verify the model
+
+  print
+  for input_vector, expected_out in gen_test_vectors( 32 ):
+    #print input_vector, expected_out
+    model.in_.value = input_vector
+    sim.eval_combinational()
+    sim.print_line_trace()
+    sim.cycle()
+    assert model.out == expected_out
+  sim.print_line_trace()
+  
+  model.destroy()
+  
+


### PR DESCRIPTION
In summary, those commits provide some convenience in terms of excluding the gigantic set_ports function call and avoiding sourcefolder variable.

1. Support restricted implicit import where ports in systemc module and ports in pymtl module are all 1-to-1 matched (for now, clk and reset also required). Currently use the ports defined in pymtl files as the port dict if there is no set_ports function call. See pymtl/tools/integration/systemc_tests/implicit_set_ports/.

2. Support nested import. If the SystemC design has a "portbundle" which adds one more layer, in set_port we could actually set pair like this: <"in.msg":s.in.msg>, where previously pymtl doesn't support dot in the left side string. In conjunction with the implicit import, we're envisioning integrating our SystemC ValRdyBundle implementation to further improve productivity. When the user plugs that bundle in the systemc design and instantiating the existing pymtl ValRdyBundle in the pymtl wrapper, Pymtl will automatically hooks up these two bundles seamlessly. Also some standard message types such as MemMsg will probably be added or automatically generated. 

3. Slightly change the sourcefolder mechanism. Now the folder path of the pymtl module (xxxSC.py) is by default included. As a result, the sourcefolder now is considered to be the "additional search path".