### PR TITLE
Add file lock to support xdist -n options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ python:
 
 env:
  - CONFIG=""
+ - CONFIG="-n 2"
  - CONFIG="-n 4"
  - CONFIG="--test-verilog"
+ - CONFIG="--test-verilog -n 2"
  - CONFIG="--test-verilog -n 4"
  - CONFIG="--dump-vcd"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ python:
 
 env:
  - CONFIG=""
+ - CONFIG="-n 4"
  - CONFIG="--test-verilog"
+ - CONFIG="--test-verilog -n 4"
  - CONFIG="--dump-vcd"
 
 #------------------------------------------------------------------------

--- a/pymtl/tools/translation/verilator_sim.py
+++ b/pymtl/tools/translation/verilator_sim.py
@@ -47,7 +47,7 @@ def TranslationTool( model_inst, lint=False, enable_blackbox=False, verilator_xi
     vcd_en = False
 
   # Get exclusive access to temp_file here
-  lock = open( ".lock","w" )
+  lock = open( ".lock_%s" % model_name,"w" )
   fcntl.flock( lock, fcntl.LOCK_EX )
   
   cached = False
@@ -75,6 +75,15 @@ def TranslationTool( model_inst, lint=False, enable_blackbox=False, verilator_xi
     # Rename temp to actual output
     os.rename( temp_file, verilog_file )
     
+    # Verilate the module only if we've updated the verilog source
+    if not cached:
+      #print( "NOT CACHED", verilog_file )
+      verilog_to_pymtl( model_inst, verilog_file, c_wrapper_file,
+                        lib_file, py_wrapper_file, vcd_en, lint,
+                        verilator_xinit )
+    #else:
+    #  print( "CACHED", verilog_file )
+
   except Exception:
     # Remember to unlock to avoid deadlock
     fcntl.flock( lock, fcntl.LOCK_UN )
@@ -82,16 +91,6 @@ def TranslationTool( model_inst, lint=False, enable_blackbox=False, verilator_xi
   
   # Yield exclusive access
   fcntl.flock( lock, fcntl.LOCK_UN )
-
-  # Verilate the module only if we've updated the verilog source
-  if not cached:
-    #print( "NOT CACHED", verilog_file )
-    verilog_to_pymtl( model_inst, verilog_file, c_wrapper_file,
-                      lib_file, py_wrapper_file, vcd_en, lint,
-                      verilator_xinit )
-  #else:
-  #  print( "CACHED", verilog_file )
-
   
   # Use some trickery to import the verilated version of the model
   sys.path.append( os.getcwd() )


### PR DESCRIPTION
Previously the reason why verilog import with -n option failes is that creating and checking the tmp file is not atomic. It is possible for two threads to create the tmp file at the same time (but only one file) and after one thread deletes the tmp file the other thread cannot find it.

Basically I wrap the code fragment that manipulates files with a fcntl file lock for verilog import and systemc import.

I also add -n option to Travis CI to show the performance difference. 