### PR TITLE
[perf] Add -O3 to verilation and remove optimization from compilation

### DIFF
--- a/pymtl/tools/translation/verilator_cffi.py
+++ b/pymtl/tools/translation/verilator_cffi.py
@@ -60,7 +60,7 @@ def verilate_model( filename, model_name, vcd_en, lint ):
   # verilator commandline template
 
   compile_cmd = ( 'verilator -cc {source} -top-module {model_name} '
-                  '--Mdir {obj_dir} {flags}' )
+                  '--Mdir {obj_dir} -O3 {flags}' )
 
   # verilator commandline options
 
@@ -454,7 +454,7 @@ Error:
 
   compile(
     # flags        = "-O1 -fstrict-aliasing -fPIC -shared -L. -lverilator",
-    flags        = "-fstrict-aliasing -fPIC -shared", # -O1 removed
+    flags        = "-O0 -fPIC -shared",
     include_dirs = include_dirs,
     output_file  = lib_file,
     input_files  = cpp_sources_list,

--- a/pymtl/tools/translation/verilator_cffi.py
+++ b/pymtl/tools/translation/verilator_cffi.py
@@ -454,7 +454,7 @@ Error:
 
   compile(
     # flags        = "-O1 -fstrict-aliasing -fPIC -shared -L. -lverilator",
-    flags        = "-O1 -fstrict-aliasing -fPIC -shared",
+    flags        = "-fstrict-aliasing -fPIC -shared", # -O1 removed
     include_dirs = include_dirs,
     output_file  = lib_file,
     input_files  = cpp_sources_list,


### PR DESCRIPTION
I did some throwaway study on a real-world workload on ece-02 teaching server. The real-world workload is "py.test ../lab2_proc/test/*RTL* --vrtl" . The reason why I call it a workload is that it includes 4 verilator calls: ProcBase, ProcAlt, ProcSimple, and DpathComponents. Besides, it has 543 test cases in total, some of which run for ~1 second and some of them are in a glimpse.

I decide to turn on -O3 for verilation and turn off optimization for compilation. The high level takeaways are the following for those Proc models (or those models as complex as those Proc).

1) Just always turn on verilator -O3 option because -O3 takes 0.7s to verilate a model but -O0 also needs 0.6s+, and hopefully -O3 will optimize something.

2) Same as verilator manual suggested, compiling with -O1 -fstrict-aliasing is as good as -O3 in terms of quality but at the same time significantly reduces compile time. However, the improvement over -O0 is within the error margin.

3) With the master branch of pymtl, the sum of prepation time over all models takes about 28 seconds. The minimum preparation time for now is 16 seconds which looks good. On my Dell XPS 13 9350 it takes only 1-2 second to prepare one proc model.

*Terminology
Verilation: calling verilator
Compilation: compiling the whole bunch of generated c++ files with the wrapper
Preparation: verilation + compilation
Simulation: as it is

* verilate: -O3

- compile: -O0
     16 seconds prepare, 135 seconds simulate

- compile: without any optimization option
     16 seconds prepare, 135 seconds simulate

- compile: -fstrict-aliasing
     16 seconds prepare, 135 seconds simulate

- compile: -O1 -fstrict-aliasing
     28 seconds prepare, 134 seconds simulate

- compile: -O3
     45 seconds prepare, 134 seconds simulate

* verilate: without any optimization option

- compile: without any optimization option
     16 seconds prepare, 136 seconds simulate

- compile: -O1 -fstrict-aliasing
     27 seconds prepare, 134 seconds simulate

- compile: -O3
     47 seconds prepare, 134 seconds simulate