### PR TITLE
Fixed bug in Bits datatype

### DIFF
--- a/pymtl/datatypes/Bits.py
+++ b/pymtl/datatypes/Bits.py
@@ -12,8 +12,8 @@ import copy
 #-----------------------------------------------------------------------
 def _get_nbits( N ):
   'Utility class for calculating number of bits needed to store a value'
-  if N > 0: return N.bit_length()
-  else:     return N.bit_length() + 1
+  if N > 0: return N.bit_length() + 1
+  else:     return N.bit_length()
 
 #-----------------------------------------------------------------------
 # Bits


### PR DESCRIPTION
Simple bug fix. According to the Python docs [here](https://docs.python.org/2/library/stdtypes.html#int.bit_length), bit_length() "[Returns] the number of bits necessary to represent an integer in binary, excluding the sign and leading zeros". 

See the example in the linked docs for negative input. For positive input we always add a 0 for the sign bit, thus the +1 for N>0