### PR TITLE
Fix Bits-slices value assignment

### DIFF
--- a/pymtl/datatypes/Bits_test.py
+++ b/pymtl/datatypes/Bits_test.py
@@ -131,6 +131,42 @@ def test_set_slice():
   with pytest.raises( ValueError ):
     x[:]   = 0b10000
 
+  # Pos and Neg bounds
+  ## Positive assigns are treated as unsigned
+  ## Negative assigns are treated as 2's complement
+
+  # Positive
+  x[:3] = 3
+  assert x.uint() == 0b1011
+
+  x[:3] = 4
+  assert x.uint() == 0b1100
+
+  x[:3] = 7
+  assert x.uint() == 0b1111
+
+  with pytest.raises( ValueError ):
+    x[:3] = 8
+
+  with pytest.raises( ValueError ):
+    x[:3] = 15
+
+  # Negative
+  x[:3] = -1
+  assert x.uint() == 0b1111
+
+  x[:3] = -3
+  assert x.uint() == 0b1101
+
+  x[:3] = -4
+  assert x.uint() == 0b1100
+
+  with pytest.raises( ValueError ):
+    x[:3] = -5
+
+  with pytest.raises( ValueError ):
+    x[:3] = -15
+
 def test_slice_bounds_checking():
 
   x = Bits( 4, 0b1100 )

--- a/pymtl/datatypes/Bits_test.py
+++ b/pymtl/datatypes/Bits_test.py
@@ -38,7 +38,9 @@ def test_int_bounds_checking():
 
   Bits( 1, 0 )
   Bits( 1, 1 )
-  with pytest.raises( ValueError ): Bits( 1, -1 )
+  # hawajkm: this should not fail
+  #with pytest.raises( ValueError ): Bits( 1, -1 )
+  Bits(1, -1)
   with pytest.raises( ValueError ): Bits( 1, -2 )
 
 def test_uint():
@@ -91,8 +93,9 @@ def test_bit_bounds_checking():
     x[4] = 1
   with pytest.raises( ValueError ):
     x[0] = 2
-  with pytest.raises( ValueError ):
-    x[3] = -1
+  #hawajkm: This shouldn't not be a problem
+  #with pytest.raises( ValueError ):
+  #  x[3] = -1
 
 def test_get_slice():
 


### PR DESCRIPTION
The problem arises because of the way the the values checked when a value is assigned to a Bits object. To better explain this, we need to consider how Bits handle value assignments. Bits class handle different value assignment in two different way: Positive Values and Negative Values. Since Bits is unsigned, positive values are treated as unsigned while negative values are treated as signed two's complement.

When a positive value is assigned to a Bits object or a slice of it, the class checks whether the value would overflow given the available number of bits considering the value to be unsigned binary. Therefore, Bits class has two different definition of the Maximum and Minimum value to be assigned as seen in the following lines:
[Bits.py:38-39](https://github.com/cornell-brg/pymtl/blob/41e9acee2f4cf50e55117cb068197d63f400cef9/pymtl/datatypes/Bits.py#L38-L39)

Checks in Bits class happens at multiple times with two different ways: either using _max and _min object attribute, or using _get_nbits() to inspect if the value can fit in the limited bits the object has.

The problem with this approach is that the check using _max and _min is conclusive and always correct as the boundary are well studied, However, the check using number of bits is flimsy as it uses bit_length() native function of the int class of Python. The symantx of bit_length() is detailed in the following page:
[int.bit_length()](https://docs.python.org/2/library/stdtypes.html#int.bit_length)

To quote:
> Return the number of bits necessary to represent an integer in binary, excluding the sign and leading zeros

The problem happens when we deal with negative numbers. In that sense, bit_length() becomes problematic as in cases where the value is a perfect exponentiation of 2, then the sign bit is implicitly included in the number of bits returned by bit_length(); therefore, finding the actual number of bits by just using bit_length() becomes dirty as more code needs to be added to check whether the number of bits needs to be incremented or not. Therefore, it is cleaner to re-write the routine to implement the logic we want. In that logic, we determine the number of bits for positive numbers as if they were unsigned and thus the equation becomes:
math.ceil( math.log( value + 1, 2 ) )

Where is the number is negative, we use the following equation
math.ceil( math.log( abs( value ), 2 ) ) + 1

Working the math for the above is straight-forward.

The last point that this pull-request fixes is how single-bit slices/Bits objects are dealt with; if we assume that the assigned values are dealt with the same logic outlined above, then it is possible that a negative value assignment could produce the same positive value assignment as the positive value is unsigned while the negative number is 2's complement signed number. Therefore, for single bits objects, the range will be from -1 to 1; -1 in 1 bit number is basically:
`1`

While unsigned 1 in 1 bit is also:
`1`

As a result, to keep things consistent and adherent to a logic, the changes in the pull request implements a strict logic of treating positive values as unsigned and negative as 2's complement values; this fixes bugs that seem to be caused by the different logic of treating both the positive and negative values.