### PR TITLE
Add AST caching to avoid redundant file scan

### DIFF
--- a/pymtl/tools/simulation/ast_visitor.py
+++ b/pymtl/tools/simulation/ast_visitor.py
@@ -32,7 +32,7 @@ class DetectIncorrectValueNext( ast.NodeVisitor ):
           ' Line: {lineno}\n'.format(
             attr     = self.attr,
             kind     = {'value':'@tick','next':'@combinational'}[ self.attr ],
-            srccode  = src[node.lineno-1],
+            srccode  = src[ node.lineno-1 ],
             filename = inspect.getfile( self.func ),
             funcname = self.func.func_name,
             lineno   = lineno,
@@ -49,8 +49,6 @@ class DetectMissingValueNext( ast.NodeVisitor ):
     self.func   = func
     self.dict_  = get_closure_dict( func )
 
-    self.src, self.funclineno = inspect.getsourcelines( self.func )
-
   def visit_Assign( self, node ):
 
     # Because the lhs could contain arbitrary nesting of tuples or lists,
@@ -66,6 +64,9 @@ class DetectMissingValueNext( ast.NodeVisitor ):
       else:
         from ..ast_helpers import print_simple_ast
         print_simple_ast( tgt )
+
+        src,funclineno = inspect.getsourcelines( self.func )
+        lineno         = funclineno + node.lineno - 1
         raise Exception(
           'Unsupported assignment type ({kind})!\n'
           'Please notify the PyMTL developers!\n\n'
@@ -75,10 +76,10 @@ class DetectMissingValueNext( ast.NodeVisitor ):
           ' Line: {lineno}\n'.format(
             attr     = self.attr[0],
             kind     = tgt.__class__,
-            srccode  = self.src[ node.lineno - 1 ],
+            srccode  = src[ node.lineno-1 ],
             filename = inspect.getfile( self.func ),
             funcname = self.func.func_name,
-            lineno   = self.funclineno + node.lineno - 1
+            lineno   = lineno,
           )
         )
 
@@ -124,6 +125,9 @@ class DetectMissingValueNext( ast.NodeVisitor ):
 
         # if the object stored in LHS is a Signal, raise a PyMTLError
         if isinstance( _temp, Signal ):
+
+          src,funclineno = inspect.getsourcelines( self.func )
+          lineno         = funclineno + node.lineno - 1
           raise PyMTLError(
             'Attempting to write a(n) {kind} without .{attr}!\n\n'
             ' {lineno} {srccode}\n'
@@ -132,10 +136,10 @@ class DetectMissingValueNext( ast.NodeVisitor ):
             ' Line: {lineno}\n'.format(
               attr     = self.attr[0],
               kind     = _temp.__class__.__name__,
-              srccode  = self.src[ node.lineno - 1 ],
+              srccode  = src[ node.lineno-1 ],
               filename = inspect.getfile( self.func ),
               funcname = self.func.func_name,
-              lineno   = self.funclineno + node.lineno - 1
+              lineno   = lineno
             )
           )
 


### PR DESCRIPTION
This PR is to reduce the redundant file inspection to parse the AST when we want to register the combinational/tick/posedge_clk blocks to the simulation. I need to fix the affected tests but just want to know people's thoughts.

As I observed from vmprof, for a 4-core, 8-cache, 3-network composition written in pure pymtl, there are 600+ instances of different models(including 10s of regs, 10s of mux, and such) and 900+ blocks, and the simulation takes only 100s of cycles. Basically, 50% percent of the time is spent on scanning the file to parse the AST for the 900+ models. What makes things worse is that we cannot reuse them across different test cases.

What I did is a "meta AST cache" which assumes the model won't change in a single py.test execution so that we could cache the parsed AST to a static array which belongs to type(model), to prevent duplicated file scan.

Having said this, this won't give us any benefit for simulation alone. The benefit makes more sense when we have hundreds of test cases to run on a fairly big module and each of them only runs for 10s or 100s cycles.

I did a "py.test lab2_proc/" for ece 4750 on my computer (file is read from PCIe SSD!) and found that with the meta cache the 282 test cases takes 135s, but without meta cache it's 205s, which is pretty good.

This approach is superior to py.test fixture because the ast meta cache is stronger i.e. it captures reuse within a single instantiation. Suppose we want to write a tile64, meta cache don't even need to parse the processor for 64 times. Py.test fixture will parse 64 times at the first time but not for the second test case.