### PR TITLE
[pymtl/model] Throw friendly error if connect() is called on Model

### DIFF
--- a/pymtl/model/Model.py
+++ b/pymtl/model/Model.py
@@ -165,6 +165,15 @@ class Model( object ):
     >>> s.connect( s.my_bundle_a, s.my_bundle_b )
     """
 
+    # Throw an error if connect() is used on a Model.
+    if isinstance( left_port, Model ) or isinstance( right_port, Model ):
+      e = ('Cannot pass a Model object to connect(). Pass the ports of the '
+           'model instead.')
+      frame, filename, lineno, func_name, lines, idx = inspect.stack()[1]
+      msg  = '{}\n\nLine: {} in File: {}\n>'.format( e, lineno, filename )
+      msg += '>'.join( lines )
+      raise PyMTLConnectError( msg )
+
     # Throw an error if connect() is used on two wires.
     if isinstance( left_port, Wire ) and isinstance( right_port, Wire ):
       e = ('Connecting two Wire signals is not supported!\n'


### PR DESCRIPTION
If `connect()` was called on a Model object, you would get a cryptic error saying "MyModel object has no attribute 'nbits'". This changes the error behavior so that it's clear that you need to pass the ports of the model object instead.