### PR TITLE
Add a prefix to verilator-xinit comment

### DIFF
--- a/pymtl/tools/translation/verilog_structural.py
+++ b/pymtl/tools/translation/verilog_structural.py
@@ -25,12 +25,12 @@ def header( model, symtab, enable_blackbox=False, verilator_xinit='zeros' ):
     value_str = '{}'.format( value )
     if 'instance at' in value_str:
       value_str = value_str.split(' at')[0] + '>'
-    s += '// {}: {}'.format( name, value_str ) + endl
+    s += '// PyMTL: {} = {}'.format( name, value_str ) + endl
 
   dump_vcd = hasattr( model, 'vcd_file' ) and model.vcd_file != ''
-  s   += '// dump-vcd: {}'.format( dump_vcd ) + endl
+  s   += '// PyMTL: dump_vcd = {}'.format( dump_vcd ) + endl
 
-  s += '// set verilator-xinit: {}'.format( verilator_xinit ) + endl
+  s += '// PyMTL: verilator_xinit = {}'.format( verilator_xinit ) + endl
 
   if enable_blackbox:
     if model.vblackbox:

--- a/pymtl/tools/translation/verilog_structural.py
+++ b/pymtl/tools/translation/verilog_structural.py
@@ -30,7 +30,7 @@ def header( model, symtab, enable_blackbox=False, verilator_xinit='zeros' ):
   dump_vcd = hasattr( model, 'vcd_file' ) and model.vcd_file != ''
   s   += '// dump-vcd: {}'.format( dump_vcd ) + endl
 
-  s += '// verilator-xinit: {}'.format( verilator_xinit ) + endl
+  s += '// set verilator-xinit: {}'.format( verilator_xinit ) + endl
 
   if enable_blackbox:
     if model.vblackbox:


### PR DESCRIPTION
This is to avoid being recognized as a special verilator comment by verilator. Verilator will sometimes (depending on the version)  recognize this `// verilator` as a verilator special comment, and throw an error when it sees `-xinit`. 3.876 doesn't have this problem, but 4.008 will. After this modification I got the failing case to work.